### PR TITLE
[ENG-748] Only flush UTM Tags if one already exists

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -1687,12 +1687,16 @@ class Api
             $utmTags = $this->getUtmTag();
             if ($originalUtmTags = $contact->getUtmTags()) {
                 $utmTags = $originalUtmTags[0];
+            } else {
+                $utmTags->setLead($contact);
             }
-            $utmTags->setLead($contact);
             $utmTags->setUtmSource($this->utmSource);
             $utmTags->setDateAdded(new \DateTime());
             $this->em->persist($utmTags);
-            $this->em->flush($utmTags);
+            if($originalUtmTags)
+            {
+                $this->em->flush($utmTags);
+            }
             $contact->setUtmTags($utmTags);
         }
     }

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -1693,8 +1693,7 @@ class Api
             $utmTags->setUtmSource($this->utmSource);
             $utmTags->setDateAdded(new \DateTime());
             $this->em->persist($utmTags);
-            if($originalUtmTags)
-            {
+            if ($originalUtmTags) {
                 $this->em->flush($utmTags);
             }
             $contact->setUtmTags($utmTags);


### PR DESCRIPTION
 and a lead is already associated, otherwise the entity relationships are not cascaded an an error occurs. [ENG_748]