### PR TITLE
[ENG-879] Parallel Schedule stop "MySQL has gone away errors"

### DIFF
--- a/EventListener/CampaignSubscriber.php
+++ b/EventListener/CampaignSubscriber.php
@@ -77,7 +77,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         $campaignIds = [
             $campaign->getId() => false,
         ];
-        $this->apiModel->kickoffParallelCampaigns($contact, $campaignIds);
+        $this->apiModel->kickoffParallelCampaigns($contact, $campaignIds, false);
 
         return;
     }
@@ -118,7 +118,7 @@ class CampaignSubscriber implements EventSubscriberInterface
             $campaignIds = [
                 $campaign->getId() => false,
             ];
-            $this->apiModel->kickoffParallelCampaigns($contact, $campaignIds);
+            $this->apiModel->kickoffParallelCampaigns($contact, $campaignIds, false);
         }
 
         return;

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -1840,9 +1840,18 @@ class Api
         }
 
         // Commit any MySQL changes and close the connection/s to prepare for a process fork.
+        if ($this->em->isOpen()) {
+            // There may be entitys ready to save.
+            try {
+                $this->em->flush();
+            } catch (\Exception $e) {
+                $this->logger->error('Attempting to flush '.$e->getMessage());
+            }
+        }
         /** @var Connection $connection */
         $connection = $this->em->getConnection();
         if ($connection) {
+            // There may be manual transactions ready to save.
             while (0 !== $connection->getTransactionNestingLevel()) {
                 // Check for RollBackOnly to avoid exceptions.
                 if (!$connection->isRollbackOnly()) {


### PR DESCRIPTION
This code looks a little funky, but it’s following the pattern of the
DBAL connection logic as much as possible. I’m supporting
non-autocommit and rollback-only even though those modes *shouldn’t* be
used in this project. With this the buffer errors do not occur.