### PR TITLE
[ENG-956] Exclude date_added as an available setter for UTM tags from…

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -1086,6 +1086,7 @@ class Api
         if (null === $this->utmSetters) {
             $utmSetters = $this->getUtmTag()->getFieldSetterList();
             unset($utmSetters['query']);
+            unset($utmSetters['date_added']);
             $this->utmSetters = $utmSetters;
         }
 


### PR DESCRIPTION
… third parties.

**Please be sure you are submitting this against the _master_ branch.**

[//]: # This Pull Request (Place an 'X' for each):

| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |  X  |     |      |
| Schema Change?                            | X   |     |      |
| Adds A Query or Modifies Existing Query?  | X   |     |      |
| Adds or Modifies Existing Auto-Enhancer?  | X   |     |      |
| Modifies Ingestion Process?               |    | X    |      |
| Modifies sendContact Data?                | X   |     |      |


[//]: # ( Required: )
#### Description:
Saw an exception by chance, which happens when a source provides a date_added field. Since technically that is a setter for UTM tag entities, it tries to accept that and set it, but it's not a DateTime object (but a string) so the result fails causing source ingestion failure as a result I belive.