### PR TITLE
[ENG-975] Duplicated Source and Client events shown when a Contact has multiple pages of events.

### DIFF
--- a/Entity/EventRepository.php
+++ b/Entity/EventRepository.php
@@ -32,7 +32,7 @@ class EventRepository extends CommonRepository
      *
      * @return array
      */
-    public function getEventsByContactId($contactId, $eventType = null, \DateTime $dateAdded = null)
+    public function getTimelineStats($leadId, $options = [])
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select([
@@ -47,27 +47,16 @@ class EventRepository extends CommonRepository
 
         $expr = $q->expr()->eq('c.contact_id', ':contactId');
         $q->where($expr)
-            ->setParameter('contactId', (int) $contactId);
+            ->setParameter('contactId', (int) $leadId);
 
-        if ($dateAdded) {
-            $expr->add(
-                $q->expr()->gte('c.date_added', ':dateAdded')
+        if (isset($options['search']) && $options['search']) {
+            $query->andWhere(
+                $query->expr()->like('cs.name', $query->expr()->literal('%' . $options['search'] . '%'))
             );
-            $q->setParameter('dateAdded', $dateAdded);
         }
 
-        if ($eventType) {
-            $expr->add(
-                $q->expr()->eq('c.type', ':type')
-            );
-            $q->setParameter('type', $eventType);
-        }
 
-        $q->setMaxResults(1);
-
-        $results = $q->execute()->fetchAll();
-
-        return $results;
+        return $this->getTimelineResults($q, $options, 'cs.name', 'c.date_added', [], ['c.date_added']);
     }
 
     /**

--- a/Entity/EventRepository.php
+++ b/Entity/EventRepository.php
@@ -51,10 +51,9 @@ class EventRepository extends CommonRepository
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(
-                $query->expr()->like('cs.name', $query->expr()->literal('%' . $options['search'] . '%'))
+                $query->expr()->like('cs.name', $query->expr()->literal('%'.$options['search'].'%'))
             );
         }
-
 
         return $this->getTimelineResults($q, $options, 'cs.name', 'c.date_added', [], ['c.date_added']);
     }

--- a/EventListener/LeadTimelineSubscriber.php
+++ b/EventListener/LeadTimelineSubscriber.php
@@ -56,7 +56,7 @@ class LeadTimelineSubscriber extends CommonSubscriber
                             'event'           => $eventTypeKey,
                             // Event name/label - can be a string or an array as below to convert to a link
                             'eventLabel'      => [
-                                'label' => $stat['sourceName'],
+                                'label' => 'Source: '.$stat['sourceName'],
                                 'href'  => "/s/contactsource/view/{$stat['contactsource_id']}",
                             ],
                             // Translated string displayed in the Event Type column
@@ -65,8 +65,8 @@ class LeadTimelineSubscriber extends CommonSubscriber
                             'timestamp'       => $stat['date_added'],
                             // Optional details passed through to the contentTemplate
                             'extra'           => [
-                                'stat' => $stat, 
-                                'logs'    => $stat['logs'],
+                                'stat'            => $stat,
+                                'logs'            => $stat['logs'],
                                 'message'         => $stat['message'],
                             ],
                             // Optional template to customize the details of the event in the timeline
@@ -78,6 +78,5 @@ class LeadTimelineSubscriber extends CommonSubscriber
                 }
             }
         }
-
     }
 }

--- a/EventListener/LeadTimelineSubscriber.php
+++ b/EventListener/LeadTimelineSubscriber.php
@@ -23,27 +23,61 @@ class LeadTimelineSubscriber extends CommonSubscriber
      */
     public function onTimelineGenerate(LeadTimelineEvent $event)
     {
-        $repo         = $this->em->getRepository('MauticContactSourceBundle:Event');
-        $sourceEvents = $repo->getEventsByContactId($event->getLeadId());
+        $eventTypeKey  = 'contact_source.send';
+        $eventTypeName = 'Contact Source';
+        $event->addEventType($eventTypeKey, $eventTypeName);
 
-        if (!is_array($sourceEvents)) {
+        // Determine if this event has been filtered out
+        if (!$event->isApplicable($eventTypeKey)) {
             return;
         }
 
-        foreach ($sourceEvents as $srcEvent) {
-            $srcEvent['eventLabel'] = [
-                'label' => 'Contact Source: '.$srcEvent['sourceName'],
-                'href'  => "/s/contactsource/view/{$srcEvent['contactsource_id']}",
-            ];
-            $srcEvent['event']     = '';
-            $srcEvent['eventType'] = ucfirst($srcEvent['type']);
-            $srcEvent['extra']     = [
-                'logs'    => $srcEvent['logs'],
-                'message' => $srcEvent['message'],
-            ];
-            $srcEvent['contentTemplate'] = 'MauticContactSourceBundle:Timeline:sourceevent.html.php';
-            $srcEvent['icon']            = 'fa-plus-square-o contact-source-button';
-            $event->addEvent($srcEvent);
+        $repo         = $this->em->getRepository('MauticContactSourceBundle:Event');
+
+        // $event->getQueryOptions() provide timeline filters, etc.
+        // This method should use DBAL to obtain the events to be injected into the timeline based on pagination
+        // but also should query for a total number of events and return an array of ['total' => $x, 'results' => []].
+        // There is a TimelineTrait to assist with this. See repository example.$repo         = $this->em->getRepository('MauticContactSourceBundle:Event');
+        $stats = $repo->getTimelineStats($event->getLeadId(), $event->getQueryOptions());
+
+        // If isEngagementCount(), this event should only inject $stats into addToCounter() to append to data to generate
+        // the engagements graph. Not all events are engagements if they are just informational so it could be that this
+        // line should only be used when `!$event->isEngagementCount()`. Using TimelineTrait will determine the appropriate
+        // return value based on the data included in getQueryOptions() if used in the stats method above.
+        $event->addToCounter($eventTypeKey, $stats);
+
+        if (!$event->isEngagementCount()) {
+            // Add the events to the event array
+            foreach ($stats['results'] as $stat) {
+                if ($stat['date_added']) {
+                    $event->addEvent(
+                        [
+                            // Event key type
+                            'event'           => $eventTypeKey,
+                            // Event name/label - can be a string or an array as below to convert to a link
+                            'eventLabel'      => [
+                                'label' => $stat['sourceName'],
+                                'href'  => "/s/contactsource/view/{$stat['contactsource_id']}",
+                            ],
+                            // Translated string displayed in the Event Type column
+                            'eventType'       => $eventTypeName,
+                            // \DateTime object for the timestamp column
+                            'timestamp'       => $stat['date_added'],
+                            // Optional details passed through to the contentTemplate
+                            'extra'           => [
+                                'stat' => $stat, 
+                                'logs'    => $stat['logs'],
+                                'message'         => $stat['message'],
+                            ],
+                            // Optional template to customize the details of the event in the timeline
+                            'contentTemplate' => 'MauticContactSourceBundle:Timeline:sourceevent.html.php',
+                            // Font Awesome class to display as the icon
+                            'icon'            => 'fa-plus-square-o contact-source-button',
+                        ]
+                    );
+                }
+            }
         }
+
     }
 }

--- a/EventListener/LeadTimelineSubscriber.php
+++ b/EventListener/LeadTimelineSubscriber.php
@@ -60,7 +60,7 @@ class LeadTimelineSubscriber extends CommonSubscriber
                                 'href'  => "/s/contactsource/view/{$stat['contactsource_id']}",
                             ],
                             // Translated string displayed in the Event Type column
-                            'eventType'       => $eventTypeName,
+                            'eventType'       => ucfirst($stat['type']),
                             // \DateTime object for the timestamp column
                             'timestamp'       => $stat['date_added'],
                             // Optional details passed through to the contentTemplate


### PR DESCRIPTION
…paginating a Contact's events

**Please be sure you are submitting this against the _master_ branch.**

[//]: # This Pull Request (Place an 'X' for each):

| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |  X  |     |      |
| Schema Change?                            |  X  |     |      |
| Adds A Query or Modifies Existing Query?  |    |   X   |      |
| Adds or Modifies Existing Auto-Enhancer?  |  X  |     |      |
| Modifies Ingestion Process?               |  X  |     |      |
| Modifies sendContact Data?                |  X  |     |      |


[//]: # ( Required: )
#### Description:
Contact Source events are filtered properly now and doesn't show on every page when a Contact's event history tab is being shown.